### PR TITLE
[BG-6202] Change master key reference to string instead of object ID

### DIFF
--- a/app/models/walletkey.js
+++ b/app/models/walletkey.js
@@ -2,7 +2,7 @@ const mongoose = require('mongoose');
 const _ = require('lodash');
 
 const walletKeySchema = new mongoose.Schema({
-  masterKey: { type: mongoose.Types.ObjectId },
+  masterKey: { type: String },
   path: { type: String },
   xpub: { type: String },
   userEmail: { type: String },


### PR DESCRIPTION
Mongo does not like querying with an object ID reference. Stores the master key as a string rather than an object ID. If we need more info, there's an indexed query on the MasterKey model by xpub.