### PR TITLE
[BG-6243] Update mongoose to fix deprecation warning

### DIFF
--- a/app/db.js
+++ b/app/db.js
@@ -6,6 +6,6 @@ if (process.env.MONGOLAB_URI) {
 }
 
 // make a new database connection and define the collections
-mongoose.connect(process.config.mongouri);
+mongoose.connect(process.config.mongouri, { useNewUrlParser: true });
 
 module.exports = mongoose;

--- a/config.js
+++ b/config.js
@@ -5,7 +5,7 @@ module.exports = {
   "port": 6833,
   "adminemail": "davidcruz@bitgo.com",
   "masterxpub": "xpub661MyMwAqRbcGnYJHEwr8CPAr6hSXC8xiMjxQi39EKyfBD99rJb7kQVqce2EFDTZutdaR2rb92xpULJqPjarYCsybvzY9AfQCkkEii6XE54",
-  "mongouri": "mongodb://localhost/key-recovery-service",
+  "mongouri": "mongodb://localhost:27017/key-recovery-service",
   "provider": {
     "id": "bitgo",
     "secret": "youshouldchangethis"

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "jsrender": "^0.9.90",
     "lodash": "^4.17.10",
     "moment": "^2.22.2",
-    "mongoose": "^5.2.4",
+    "mongoose": "^5.2.5",
     "mongoose-q": "^0.1.0",
     "morgan": "^1.9.0",
     "nodemailer": "^4.6.7",


### PR DESCRIPTION
Fixes the "current URL string parser is deprecated" by updating mongoose and using the new requirements for mongo URIs.