### PR TITLE
[BG-5837] Create route to provision a new wallet key

### DIFF
--- a/app/admin.js
+++ b/app/admin.js
@@ -124,4 +124,4 @@ const run = co(function *() {
 });
 
 // For admin script and unit testing of functions
-module.exports = { run, validateXpub, deriveKey };
+module.exports = { run, validateXpub };

--- a/app/admin.js
+++ b/app/admin.js
@@ -11,6 +11,7 @@ const prova = require('prova-lib');
 
 const db = require('./db.js');
 const MasterKey = require('./models/masterkey.js');
+const utils = require('./utils');
 
 const parser = new ArgumentParser({
   version: pjson.version,
@@ -104,15 +105,9 @@ const handleImportKeys = co(function *(args) {
     }));
 });
 
-const deriveKey = function(masterKey, derivationPath) {
-  const masterNode = prova.HDNode.fromBase58(masterKey);
-
-  return masterNode.derivePath(derivationPath).toBase58();
-};
-
 const handleDeriveKey = function(args) {
   try {
-    const childKey = deriveKey(args.master, args.path);
+    const childKey = utils.deriveChildKey(args.master, args.path);
     console.log(` = ${childKey}`);
   } catch (e) {
     console.log(e.message);

--- a/app/models/recoveryrequest.js
+++ b/app/models/recoveryrequest.js
@@ -1,5 +1,4 @@
 var mongoose = require('mongoose');
-var mongooseQ = require('mongoose-q')(mongoose);
 var _ = require('lodash');
 
 var recoverySchema = new mongoose.Schema({

--- a/app/templates/databaselow.html
+++ b/app/templates/databaselow.html
@@ -1,0 +1,9 @@
+<html>
+<head>
+    <title>URGENT: KRS MASTER KEY DATABASE LOW</title>
+</head>
+<body>
+<h1 style="text-align: center;">URGENT: KRS MASTER KEY DATABASE LOW</h1>
+<h3>The master key database has {{:availableKeys}} available keys remaining. If this number is depleted, the service will be unavailable for all new customers, as well as customers opening their first wallet of a specific coin. Please use the KRS Admin CLI tool to import new public keys ASAP.</h3>
+</body>
+</html>

--- a/app/utils.js
+++ b/app/utils.js
@@ -2,13 +2,15 @@ const Q = require('q');
 const nodemailer = require('nodemailer');
 const smtpTransport = require('nodemailer-smtp-transport');
 const jsrender = require('jsrender');
+const prova = require('prova-lib');
 
 process.config = require('../config');
 
+let sendMail;
 if (process.config.mail) {
   // create reusable transporter object using SMTP transport
   const mailTransport = nodemailer.createTransport(smtpTransport(process.config.mail));
-  const sendMail = Q.nbind(mailTransport.sendMail, mailTransport);
+  sendMail = Q.nbind(mailTransport.sendMail, mailTransport);
 }
 
 // Error response container for handling by the promise wrapper
@@ -82,4 +84,10 @@ exports.sendMailQ = function(toEmail, subject, template, templateParams, attachm
 
 exports.formatBTCFromSatoshis = function(satoshis) {
   return (satoshis * 1e-8).toFixed(4);
+};
+
+exports.deriveChildKey = function(masterXpub, derivationPath) {
+  const masterNode = prova.HDNode.fromBase58(masterXpub);
+
+  return masterNode.derivePath(derivationPath).toBase58();
 };

--- a/config.js
+++ b/config.js
@@ -23,5 +23,6 @@ module.exports = {
     "clients": {
       "bitgo": "changeThisSecret"
     }
-  }
+  },
+  "lowKeyWarningLevels": [10000, 5000, 1000, 500, 100, 0]
 }

--- a/package.json
+++ b/package.json
@@ -13,8 +13,7 @@
     "istanbul": "0.3.13",
     "mocha": "^5.2.0",
     "should": "^13.2.1",
-    "supertest": "0.15.0",
-    "supertest-as-promised": "2.0.2"
+    "supertest": "^3.1.0"
   },
   "dependencies": {
     "argparse": "^1.0.10",
@@ -26,7 +25,6 @@
     "lodash": "^4.17.10",
     "moment": "^2.22.2",
     "mongoose": "^5.2.5",
-    "mongoose-q": "^0.1.0",
     "morgan": "^1.9.0",
     "nodemailer": "^4.6.7",
     "nodemailer-smtp-transport": "^2.7.4",
@@ -34,7 +32,6 @@
     "prova-lib": "^0.2.9",
     "q": "^1.5.1",
     "superagent": "^3.8.3",
-    "superagent-as-promised": "^4.0.0",
     "validator": "^10.4.0"
   }
 }

--- a/test/admin.js
+++ b/test/admin.js
@@ -1,6 +1,7 @@
 const should = require('should');
 
 const admin = require('../app/admin.js');
+const utils = require('../app/utils.js');
 
 describe('Offline Admin Tool', function() {
   describe('Xpub validation', function() {
@@ -63,7 +64,7 @@ describe('Offline Admin Tool', function() {
       it('should find m/0 of test vector 2', function() {
         const M_0 = 'xpub69H7F5d8KSRgmmdJg2KhpAK8SR3DjMwAdkxj3ZuxV27CprR9LgpeyGmXUbC6wb7ERfvrnKZjXoUmmDznezpbZb7ap6r1D3tgFxHmwMkQTPH';
 
-        admin.deriveKey(MASTER_XPUB, 'm/0').should.equal(M_0);
+        utils.deriveChildKey(MASTER_XPUB, 'm/0').should.equal(M_0);
       })
     })
   })

--- a/test/app.js
+++ b/test/app.js
@@ -1,10 +1,8 @@
 const testutils = require('./testutils');
-const request = require('supertest-as-promised');
+const request = require('supertest');
 const should = require('should');
 const server = require('../app/app')();
 const _ = require('lodash');
-
-const RecoveryRequest = require('../app/models/recoveryrequest');
 
 describe('Application Server', function() {
   let agent;
@@ -23,43 +21,70 @@ describe('Application Server', function() {
     });
   });
 
-  // describe('Provision new key', function() {
-  //   it('no useruserEmail specified', function() {
-  //     return agent
-  //     .post('/key')
-  //     .then(function(res) {
-  //       res.status.should.eql(400);
-  //     });
-  //   });
-  //   it('should return a new key', function() {
-  //     return agent
-  //     .post('/key')
-  //     .send({userEmail: 'test@example.com', notificationURL: 'https://test.bitgo.com'})
-  //     .then(function(res) {
-  //       res.status.should.eql(200);
-  //       should.exist(res.body.path);
-  //       res.body.path.substr(0, 2).should.equal('m/');
-  //       should.exist(res.body.xpub);
-  //       res.body.xpub.substr(0, 4).should.equal('xpub');
-  //       res.body.userEmail.should.equal('test@example.com');
-  //     });
-  //   });
-  //
-  //   it('should inform a local instance of BitGo WWW about the new key', function() {
-  //     return agent
-  //     .post('/key')
-  //     .send({userEmail: 'test@example.com', notificationURL: 'http://localhost:3000/api/v1/keychain/webhook'})
-  //     .then(function(res) {
-  //       res.status.should.eql(200);
-  //       should.exist(res.body.path);
-  //       res.body.path.substr(0, 2).should.equal('m/');
-  //       should.exist(res.body.xpub);
-  //       res.body.xpub.substr(0, 4).should.equal('xpub');
-  //       res.body.userEmail.should.equal('test@example.com');
-  //     });
-  //   });
-  // });
-  //
+  describe('Provision new key', function() {
+    it('no userEmail specified', function () {
+      return agent
+        .post('/key')
+        .send({
+          customerId: 'enterprise-id',
+          coin: 'btc',
+        })
+        .then(function (res) {
+          res.status.should.eql(400);
+        });
+    });
+
+    it('no customer ID', function () {
+      return agent
+        .post('/key')
+        .send({
+          coin: 'btc',
+          userEmail: 'test@example.com'
+        })
+        .then(function (res) {
+          res.status.should.eql(400);
+        })
+    });
+
+    it('no coin type', function () {
+      return agent
+        .post('/key')
+        .send({
+          customerId: 'enterprise-id',
+          userEmail: 'test@example.com'
+        })
+        .then(function (res) {
+          res.status.should.eql(400);
+        })
+    });
+
+    it('should return a new key', function () {
+      return agent
+        .post('/key')
+        .send({
+          customerId: 'enterprise-id',
+          coin: 'btc',
+          userEmail: 'test@example.com',
+          custom: {
+            'anyCustomField': 'hello world'
+          }
+        })
+        .then(function (res) {
+          res.status.should.eql(200);
+          should.exist(res.body.path);
+          res.body.path.substr(0, 2).should.equal('m/');
+          should.exist(res.body.masterKey);
+          res.body.masterKey.substr(0, 4).should.equal('xpub');
+          should.exist(res.body.xpub);
+          res.body.xpub.substr(0, 4).should.equal('xpub');
+          res.body.userEmail.should.equal('test@example.com');
+          should.exist(res.body.custom);
+          should.exist(res.body.custom.anyCustomField);
+          res.body.custom.anyCustomField.should.equal('hello world');
+        });
+    });
+  });
+
   // describe('Validate key', function() {
   //   var path;
   //   var xpub;


### PR DESCRIPTION
Exposes the /key route, which derives a wallet key off of the customer/coin's master key, allocating a master key if necessary.

NOTE: I'm not yet happy with the unit tests, so I will not merge this yet. I want to test cases where the test suite is certain that a master key already exists, or does not exist, or no master keys are available. PR #8 has some nice test database construction/deconstruction code, so I'll wait for that to land and then write more tests. But I wanted to get this PR up so we can start reviewing the actual logic now.

/key expects the following parameter's in the POST request's body:
 - customerId: public ID of the enterprise or user requesting the key
 - coin: coin ticker (btc, eth, ltc...)
 - userEmail: email address of the user creating the wallet. this is not a unique identifier (that's the purpose of the customerId), but rather exists so that the KRS provider can contact the user to inform them that the key has been created, or during the recovery process
 - notificationURL: for heavy API customers, the keyserver will fire off a notification to this URL so that customers can take note of their public key without receiving an email for every wallet
 - disableKRSEmail: when set to true, will not send an email to the user's email address. usually used in tandem with notificationURL
 - custom: can be any additional information, such as phone number
 - requesterId: when running in secure mode, the platform needs to identify itself
 - requesterSecret: when running in secure mode, the platform uses this to authenticate with the keyserver