### PR TITLE
[BG-7181] Specify supported coins

### DIFF
--- a/app/krs.js
+++ b/app/krs.js
@@ -97,6 +97,10 @@ exports.provisionKey = co(function *(req) {
     throw utils.ErrorResponse(400, 'coin type required');
   }
 
+  if (!process.config.supportedcoins.includes(req.body.coin)) {
+    throw utils.ErrorResponse(400, 'unsupported coin');
+  }
+
   const userEmail = req.body.userEmail;
   if (!userEmail) {
     throw utils.ErrorResponse(400, 'email required');

--- a/config.js
+++ b/config.js
@@ -1,6 +1,7 @@
 module.exports = {
   "name": "Friendly Key Backup Service",
   "serviceurl": "http://keyrecoveryservice.yourdomain.com/",
+  "supportedcoins": ["btc", "eth", "ltc", "bch", "zec", "xrp"],
   "host": "0.0.0.0",
   "port": 6833,
   "adminemail": "davidcruz@bitgo.com",

--- a/test/app.js
+++ b/test/app.js
@@ -10,6 +10,10 @@ describe('Application Server', function() {
     agent = request.agent(server);
   });
 
+  after(function() {
+    testutils.mongoose.connection.close();
+  });
+
   describe('GET /', function() {
     it('should return the name', function() {
       return agent
@@ -56,6 +60,19 @@ describe('Application Server', function() {
         .then(function (res) {
           res.status.should.eql(400);
         })
+    });
+
+    it('unsupported coin', function () {
+      return agent
+        .post('/key')
+        .send({
+          customerId: 'enterprise-id',
+          coin: 'bitconnect',
+          userEmail: 'test@example.com'
+        })
+        .then(function (res) {
+          res.status.should.eql(400);
+        });
     });
 
     it('should return a new key', function () {


### PR DESCRIPTION
Allow service providers to choose which coins they want to support with an array in config.js