### PR TITLE
[BG-7182] Generate hardened child keys as master keys

### DIFF
--- a/app/krs.js
+++ b/app/krs.js
@@ -123,7 +123,7 @@ exports.provisionKey = co(function *(req) {
   }
 
   key.masterKey = masterKey.xpub;
-  key.path = `m/${masterKey.keyCount}`;
+  key.path = masterKey.keyCount;
   key.xpub = utils.deriveChildKey(key.masterKey, key.path);
 
   key.userEmail = req.body.userEmail;

--- a/app/models/masterkey.js
+++ b/app/models/masterkey.js
@@ -5,16 +5,18 @@ const masterKeySchema = new mongoose.Schema({
   coin: { type: String },
   customerId: { type: String },
   xpub: { type: String },
+  path: { type: String },
   keyCount: { type: Number }
 });
 
 masterKeySchema.methods = {
   toJSON: function() {
-    return _.pick(this, ['coin', 'customerId', 'xpub', 'keyCount']);
+    return _.pick(this, ['coin', 'customerId', 'xpub', 'path', 'keyCount']);
   }
 };
 
 masterKeySchema.index({ customerId: 1, coin: 1 }, { unique: true, sparse: true });
 masterKeySchema.index({ xpub: 1 }, { unique: true });
+masterKeySchema.index({ path: 1 }, { unique: true });
 
 module.exports = mongoose.connection.model('masterKey', masterKeySchema);

--- a/package.json
+++ b/package.json
@@ -4,13 +4,12 @@
   "description": "Key service implementing KRS protocol to provision xpubs for backup use",
   "main": "index.js",
   "scripts": {
-    "test": "./node_modules/.bin/istanbul cover ./node_modules/.bin/_mocha -- --recursive",
+    "test": "./node_modules/.bin/_mocha -- --timeout 20000 --recursive test/",
     "start": "node bin/server.js"
   },
   "license": "MIT",
   "devDependencies": {
     "chai": "2.2.0",
-    "istanbul": "^0.4.5",
     "mocha": "^5.2.0",
     "should": "^13.2.1",
     "supertest": "^3.1.0"
@@ -18,6 +17,7 @@
   "dependencies": {
     "argparse": "^1.0.10",
     "bitcoinjs-message": "^2.0.0",
+    "bitgo-utxo-lib": "^1.1.2",
     "body-parser": "^1.18.3",
     "csv-parse": "^2.5.0",
     "express": "^4.16.3",

--- a/test/admin.js
+++ b/test/admin.js
@@ -19,27 +19,27 @@ describe('Offline Admin Tool', function() {
     // and successfully saved to local Mongo instance
     describe('failure', function() {
       it('should fail if length is not 111', function() {
-        const SHORT_XPUB = 'xpub1234567890';
+        const SHORT_XPUB = { path: 'm/0\'', xpub: 'xpub1234567890'};
 
         admin.validateXpub(SHORT_XPUB).should.equal(false);
       });
 
       it('should fail if does not start with xpub', function() {
-        const BAD_PREFIX_XPUB = 'xprv9wHokC2KXdTSpEepFcu53hMDUHYfAtTaLEJEMyxBPAMf78hJg17WhL5FyeDUQH5KWmGjGgEb2j74gsZqgupWpPbZgP6uFmP8MYEy5BNbyET';
+        const BAD_PREFIX_XPUB = { path: 'm/0\'', xpub: 'xprv9wHokC2KXdTSpEepFcu53hMDUHYfAtTaLEJEMyxBPAMf78hJg17WhL5FyeDUQH5KWmGjGgEb2j74gsZqgupWpPbZgP6uFmP8MYEy5BNbyET'};
 
         admin.validateXpub(BAD_PREFIX_XPUB).should.equal(false);
       });
 
       it('should fail if not base58 valid', function() {
-        const BAD_CHARS_XPUB = 'xpub0OIl0OIl6t7aLemM4KiBoLBYQ5j9G2SVpNTojw7Vki3j7wcM3NRPVmDjnjwQREzPcywEg793M89odNXWneRQkn1eWjptpukDwJQVgVLRHKV'
+        const BAD_CHARS_XPUB = { path: 'm/0\'', xpub: 'xpub0OIl0OIl6t7aLemM4KiBoLBYQ5j9G2SVpNTojw7Vki3j7wcM3NRPVmDjnjwQREzPcywEg793M89odNXWneRQkn1eWjptpukDwJQVgVLRHKV' };
 
         admin.validateXpub(BAD_CHARS_XPUB).should.equal(false);
       });
     });
 
     describe('success', function() {
-      it('should succeed with a valid xpub', function() {
-        const GOOD_XPUB = 'xpub6B7XuUcPQ9MeszNzaTTGtni9W79MmFnHa7FUe7Hrbv3pefnaDFCHtJWaWdg1FVbocHhivnCRTCbHTjDrMBEyAGDJHGyqCnLhtEWP2rtb1sL';
+      it('should succeed with a valid key', function() {
+        const GOOD_XPUB = { path: 'm/0\'', xpub: 'xpub6B7XuUcPQ9MeszNzaTTGtni9W79MmFnHa7FUe7Hrbv3pefnaDFCHtJWaWdg1FVbocHhivnCRTCbHTjDrMBEyAGDJHGyqCnLhtEWP2rtb1sL' };
 
         admin.validateXpub(GOOD_XPUB).should.equal(true);
       });


### PR DESCRIPTION
DAI requested that we automate the generation of master keys as hardened child keys of a single xprv. Added an admin tool command ``admin.js generate`` which generates a large number of private keys and stores them to a file. These private keys are imported with the import tool as before.