### PR TITLE
[BG-7446] Add Stellar key support

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,8 @@
     "prompt-sync": "^4.1.6",
     "prova-lib": "^0.2.9",
     "q": "^1.5.1",
+    "stellar-base": "^0.8.3",
+    "stellar-hd-wallet": "0.0.8",
     "superagent": "^3.8.3",
     "validator": "^10.4.0"
   }


### PR DESCRIPTION
**WIP**

Action items:
[x] Support for generating Stellar keys in the offline admin tool from a seed (hex)
[ ] Model upgrade to store the type of key with each master key
[ ] Set the type of key when importing with the admin tool
[ ] Short command to generate a random seed hex (with crypto.randomBytes)
[ ] Correctly dispense a Stellar key when the coin requested is xlm, otherwise return an xprv
[ ] Unit tests for retrieving Stellar keys