### PR TITLE
BG-11612 use FromBase58 to sign with key from path

### DIFF
--- a/app/sign.js
+++ b/app/sign.js
@@ -342,7 +342,7 @@ const parseKey = function(rawkey, coin, path) {
   }
   // if it doesn't have commas, we expect it is an xprv or xlmsecret properly formatted
   if(path) {
-    let node = utxoLib.HDNode.fromPrivateKeyBuffer(Buffer.from(rawkey, 'hex'));
+    let node = utxoLib.HDNode.fromBase58(rawkey);
     node = node.derivePath(path);
     return node.toBase58();
   }


### PR DESCRIPTION
## Motivation
https://bitgoinc.atlassian.net/browse/BG-11612

## Overview Of Changes
When a user signs, we expect them to enter a key of the xprv format. However this line I'm changing is incorrect as its expecting a hex-formatted key
