### PR TITLE
Fix broken unit tests

### DIFF
--- a/app/admin.js
+++ b/app/admin.js
@@ -208,7 +208,7 @@ const validateKey = function(key, type) {
   if (process.config.verificationPub) {
 
     if (!key.signature) {
-      console.log(`Key ${key.pub} requires a signature and does not have one.`);
+      console.log(`Key ${key.pub} has a verification public key but no signature.`);
       return false;
     }
 

--- a/app/sign.js
+++ b/app/sign.js
@@ -78,6 +78,12 @@ const confirmRecovery = function(backupKey, outputs, customMessage, skipConfirm)
   }
 };
 
+/**
+ * Verifies that input is a valid HD key and parses it into HDNode object.
+ * @param xprv Base58 representation of extended private key
+ * @param expectedXpub The corresponding extended public key
+ * @returns The HDNode object representing the extended private key
+ */
 const getHDNodeAndVerify = function(xprv, expectedXpub) {
   let node;
 
@@ -99,7 +105,7 @@ const getHDNodeAndVerify = function(xprv, expectedXpub) {
 };
 
 /**
- * Prints the recovery transaction information and prompt for the confirmation as well as the key, if needed to.
+ * Prints the recovery transaction information and prompt the user for the confirmation as well as the key, if needed to.
  * @param recoveryRequest The recovery transansaction request object.
  * @param outputs The outputs of the transaction.
  * @param skipConfirm The boolean value that indicates to whether or not to prompt the user to confirm the transaction.

--- a/app/sign.js
+++ b/app/sign.js
@@ -120,14 +120,14 @@ const promptForConfirmationAndKey = function(recoveryRequest, outputs, skipConfi
 
 /**
  * Gets the backup private key that can be used to sign the transaction.
- * @param key The provided private key.
+ * @param xprv The provided extended private key (BIP32).
  * @param expectedXpub The public key specified with the request. 
  * @returns The private key to sign the transaction.
  */
-const getBackupSigningKey = function(key, expectedXpub) {
-  const backupKeyNode = getHDNodeAndVerify(key, expectedXpub);
+const getBackupSigningKey = function(xprv, expectedXpub) {
+  const backupKeyNode = getHDNodeAndVerify(xprv, expectedXpub);
 
-  return backupKeyNode.keyPair.getPrivateKeyBuffer;
+  return backupKeyNode.keyPair.getPrivateKeyBuffer();
 }
 
 const handleSignUtxo = function(recoveryRequest, key, skipConfirm) {
@@ -237,8 +237,9 @@ const signEthTx = function(recoveryRequest, key, skipConfirm, isToken) {
   }
 
   key = promptForConfirmationAndKey(recoveryRequest, outputs, skipConfirm, key);
+  const signingKey = getBackupSigningKey(key, recoveryRequest.backupKey);
 
-  transaction.sign(getBackupSigningKey(key, recoveryRequest.backupKey));
+  transaction.sign(signingKey);
 
   return transaction.serialize().toString('hex');
 };
@@ -258,8 +259,9 @@ const handleSignTrx = function(recoveryRequest, key, skipConfirm) {
   });
 
   key = promptForConfirmationAndKey(recoveryRequest, outputs, skipConfirm, key);
+  const signingKey = getBackupSigningKey(key, recoveryRequest.backupKey);
 
-  builder.sign({ key: getBackupSigningKey(key, recoveryRequest.backupKey) });
+  builder.sign({ key: signingKey });
   return JSON.stringify(builder.build().toJson());
 };
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -117,7 +117,6 @@
       "version": "4.11.5",
       "resolved": "https://registry.npmjs.org/@types/bn.js/-/bn.js-4.11.5.tgz",
       "integrity": "sha512-AEAZcIZga0JgVMHNtl1CprA/hXX7/wPt79AgR4XqaDt7jyj3QWYw6LPoOiznPtugDmlubUnAahMs2PFxGcQrng==",
-      "optional": true,
       "requires": {
         "@types/node": "*"
       }
@@ -509,6 +508,19 @@
             }
           }
         },
+        "ethereumjs-util": {
+          "version": "4.5.0",
+          "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-4.5.0.tgz",
+          "integrity": "sha1-PpQosxfuvaPXJg2FT93alUsfG8Y=",
+          "optional": true,
+          "requires": {
+            "bn.js": "^4.8.0",
+            "create-hash": "^1.1.2",
+            "keccakjs": "^0.2.0",
+            "rlp": "^2.0.0",
+            "secp256k1": "^3.0.1"
+          }
+        },
         "ripple-lib": {
           "version": "0.22.0",
           "resolved": "https://registry.npmjs.org/ripple-lib/-/ripple-lib-0.22.0.tgz",
@@ -566,6 +578,53 @@
           "version": "0.0.3",
           "resolved": "https://registry.npmjs.org/bech32/-/bech32-0.0.3.tgz",
           "integrity": "sha512-O+K1w8P/aAOLcYwwQ4sbiPYZ51ZIW95lnS4/6nE8Aib/z+OOddQIIPdu2qi94qGDp4HhYy/wJotttXKkak1lXg=="
+        }
+      }
+    },
+    "bl": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-2.2.0.tgz",
+      "integrity": "sha512-wbgvOpqopSr7uq6fJrLH8EsvYMJf9gzfo2jCsL2eTy75qXPukA4pCgHamOQkZtY5vmfVtjB+P3LNlMHW5CEZXA==",
+      "requires": {
+        "readable-stream": "^2.3.5",
+        "safe-buffer": "^5.1.1"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "2.3.7",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+          "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
+          },
+          "dependencies": {
+            "safe-buffer": {
+              "version": "5.1.2",
+              "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+              "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+            }
+          }
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+          "requires": {
+            "safe-buffer": "~5.1.0"
+          },
+          "dependencies": {
+            "safe-buffer": {
+              "version": "5.1.2",
+              "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+              "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+            }
+          }
         }
       }
     },
@@ -725,9 +784,9 @@
       }
     },
     "bson": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/bson/-/bson-1.1.1.tgz",
-      "integrity": "sha512-jCGVYLoYMHDkOsbwJZBCqwMHyH4c+wzgI9hG7Z6SZJRXWr+x58pdIbm2i9a/jFGCkRJqRUr8eoI7lDWa0hTkxg=="
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/bson/-/bson-1.1.3.tgz",
+      "integrity": "sha512-TdiJxMVnodVS7r0BdL42y/pqC9cL2iKynVwA0Ho3qbsQYr428veL3l7BQyuqiw+Q5SqqoT0m4srSY/BlZ9AxXg=="
     },
     "buffer-equals": {
       "version": "1.0.4",
@@ -982,6 +1041,11 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
+    },
+    "denque": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/denque/-/denque-1.4.1.tgz",
+      "integrity": "sha512-OfzPuSZKGcgr96rf1oODnfjqBFmr1DVoc/TrItj3Ohe0Ah1C5WX5Baquw/9U9KovnQ88EqmJbD66rKYUQYN1tQ=="
     },
     "depd": {
       "version": "1.1.2",
@@ -1396,15 +1460,16 @@
       }
     },
     "ethereumjs-util": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-4.5.0.tgz",
-      "integrity": "sha1-PpQosxfuvaPXJg2FT93alUsfG8Y=",
-      "optional": true,
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-6.2.0.tgz",
+      "integrity": "sha512-vb0XN9J2QGdZGIEKG2vXM+kUdEivUfU6Wmi5y0cg+LRhDYKnXIZ/Lz7XjFbHRR9VIKq2lVGLzGBkA++y2nOdOQ==",
       "requires": {
-        "bn.js": "^4.8.0",
+        "@types/bn.js": "^4.11.3",
+        "bn.js": "^4.11.0",
         "create-hash": "^1.1.2",
-        "keccakjs": "^0.2.0",
-        "rlp": "^2.0.0",
+        "ethjs-util": "0.1.6",
+        "keccak": "^2.0.0",
+        "rlp": "^2.2.3",
         "secp256k1": "^3.0.1"
       }
     },
@@ -2037,7 +2102,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/keccak/-/keccak-2.0.0.tgz",
       "integrity": "sha512-rKe/lRr0KGhjoz97cwg+oeT1Rj/Y4cjae6glArioUC8JBF9ROGZctwIaaruM7d7naovME4Q8WcQSO908A8qcyQ==",
-      "optional": true,
       "requires": {
         "bindings": "^1.2.1",
         "inherits": "^2.0.3",
@@ -2242,24 +2306,26 @@
       "integrity": "sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg=="
     },
     "mongodb": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-3.3.3.tgz",
-      "integrity": "sha512-MdRnoOjstmnrKJsK8PY0PjP6fyF/SBS4R8coxmhsfEU7tQ46/J6j+aSHF2n4c2/H8B+Hc/Klbfp8vggZfI0mmA==",
+      "version": "3.5.5",
+      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-3.5.5.tgz",
+      "integrity": "sha512-GCjDxR3UOltDq00Zcpzql6dQo1sVry60OXJY3TDmFc2SWFY6c8Gn1Ardidc5jDirvJrx2GC3knGOImKphbSL3A==",
       "requires": {
+        "bl": "^2.2.0",
         "bson": "^1.1.1",
+        "denque": "^1.4.1",
         "require_optional": "^1.0.1",
         "safe-buffer": "^5.1.2",
         "saslprep": "^1.0.0"
       }
     },
     "mongoose": {
-      "version": "5.7.8",
-      "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-5.7.8.tgz",
-      "integrity": "sha512-GsFXYo7z3ebnIDdnqlDJYQXQFqEGS+yxfdY9G0B7fxpvUJchDpwLGuGJdVd1QbGxu2l0DscCYBO0ntl3G6OACA==",
+      "version": "5.9.5",
+      "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-5.9.5.tgz",
+      "integrity": "sha512-2kMNZCZRWCMtww4f//CwdGH6BjO3+9/c3YdsC6nbzdJVyl8+GRtNfgrKUge3226VZXXLJa6LwxXN2K8/Dh4irg==",
       "requires": {
         "bson": "~1.1.1",
         "kareem": "2.3.1",
-        "mongodb": "3.3.3",
+        "mongodb": "3.5.5",
         "mongoose-legacy-pluralize": "1.0.2",
         "mpath": "0.6.0",
         "mquery": "3.2.2",
@@ -3238,9 +3304,9 @@
       }
     },
     "sha3": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/sha3/-/sha3-1.2.3.tgz",
-      "integrity": "sha512-sOWDZi8cDBRkLfWOw18wvJyNblXDHzwMGnRWut8zNNeIeLnmMRO17bjpLc7OzMuj1ASUgx2IyohzUCAl+Kx5vA==",
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/sha3/-/sha3-1.2.6.tgz",
+      "integrity": "sha512-KgLGmJGrmNB4JWVsAV11Yk6KbvsAiygWJc7t5IebWva/0NukNrjJqhtKhzy3Eiv2AKuGvhZZt7dt1mDo7HkoiQ==",
       "optional": true,
       "requires": {
         "nan": "2.13.2"

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "eosjs": "^16.0.9",
     "eosjs-ecc": "^4.0.4",
     "ethereumjs-tx": "^1.3.7",
+    "ethereumjs-util": "6.2.0",
     "express": "^4.16.3",
     "jsrender": "^0.9.90",
     "lodash": "^4.17.11",

--- a/test/sign.js
+++ b/test/sign.js
@@ -36,6 +36,7 @@ describe('Offline Signing Tool', function() {
     txHex.should.equal('0100000002a78a1ff21efe8ceab2313cc72fac9511cbbb25af813b23410a9d402df1b990b500000000fdfe0000483045022100c425fb29056467a9f2c1d36425af1fffd61ad144054b901bcc8f05e492ae1889022074e347f91d613835273dc748914845514c3518898f74db50fb8de101d4a1faed014830450221008d10d818f5a2bb5243fd0f7b2e93073a931aa58e3b1955c84a4cc515f8d90ebf022063e5689c9a7424a0013101273a1b043a4be41d2f5cf5698f81ce3ba215114dca014c695221029c96401cdc64e0770e919e83fa52253a357b8d1b9ce4a71b08e87a2f6f4bf5212103292baef857797fcb2305cd637796d028f546e369011fa21818c91ae5e99454f32102226a4fa945adb0111e485b45165aab1de6fe8ad576e40d0049e6ab977ddda4e953aeffffffffe31818827c8777254590bff08f827dde9a741b2565dbfdc297a2fe56538b457b00000000fdfd0000483045022100e83143cd33f52c03032969aa4b1ef8c00ceec25dbfa789501a5c443ba8c8a9d4022040c6069871e848354157e331879aca88dd44a677db4836d3eed7dc853a4fae2e01473044022035add75708e034aa652914aa9c5275a8804bf9cd20b248390adddacba0712fe502202e8105656fc71e78946225f74af60b9f70eaa4afc5b49cb69c19b408240be4c7014c6952210291aa18f30c870f48af409c0f7718c0e53442a6c5238fe364c3a2c6b218943be5210285c12449fe9bf5b79661db21b6d394291220285a0985e6f3f9cac5aad0ca2fd22103d184ca13c0cb96bcfbde0ef891b1e6290200a43f75cbf1dc80e6c802465d0b4353aeffffffff01c832c3230000000017a914541703db4b42397e985b38993a52dbb5373526c58700000000');
   });
 
+  // function called in transaction: sendMultiSig, see https://bloxy.info/functions/39125215, pre-EIP155
   it('cosigns a teth transaction', function() {
     const recoveryRequest = JSON.parse(fs.readFileSync('./test/transactions/teth.json', { encoding: 'utf8' }));
     const key = 'xprv9s21ZrQH143K3vqGSfKp56taWfrBxApx9p6ySyWqFGXBrfJyDGaUErjpUu6RW7EjKmynii8zzp2b1AWno9JgVevuG3S8DqY97GHN59XMBfN';
@@ -86,6 +87,7 @@ describe('Offline Signing Tool', function() {
     tx.signature.length.should.equal(2);
   });
 
+  // function called in transaction: sendMultiSigToken, see https://bloxy.info/functions/0dcd7a6c, pre-EIP155
   it('cosigns an erc20 transaction', function() {
     const recoveryRequest = JSON.parse(fs.readFileSync('./test/transactions/terc.json', { encoding: 'utf8' }));
     const key = 'xprv9s21ZrQH143K2SGfLqMk9eaSbix4XUqXg2wqXkATpfnQsyvaXBTnEqi71aLSq1rL3qJh32FRrA2VnrfMMEmbNS5xnRCiNSHKdAVR6Ep5Ptx';


### PR DESCRIPTION
Addressing #64 
Fixes:
- adds ethereumjs-util to package.json
- Fixes broken tests in `test/sign.js`
- Upgrading to to latest nodejs (v12.16.1) will make the import of the ripple library work
- Fixes a problem in a Stellar unit test when upgrading to node 12
- In my setup, the tests only work when run sequentially since we are not awaiting
  when writing to the database and `close()` is called on the DB connection before
  writing is completed.
  `node.exe ./node_modules/mocha/bin/_mocha --timeout 20000 .\test\app.js`,
  `node.exe ./node_modules/mocha/bin/_mocha --timeout 20000 .\test\sign.js`,
  `node.exe ./node_modules/mocha/bin/_mocha --timeout 20000 .\test\admin.js`
- `npm test` works correctly if a `sleep(500)` is inserted before the call to `testutils.mongoose.connection.close();`. A better solution might be to add `await` on each DB save.
