### PR TITLE
refactor(utils): remove prova dependency

### DIFF
--- a/app/utils.js
+++ b/app/utils.js
@@ -5,7 +5,6 @@ const binary = require('ripple-binary-codec');
 const nodemailer = require('nodemailer');
 const smtpTransport = require('nodemailer-smtp-transport');
 const jsrender = require('jsrender');
-const prova = require('prova-lib');
 const utxoLib = require('bitgo-utxo-lib');
 const stellar = require('stellar-base');
 const stellarHd = require('stellar-hd-wallet');
@@ -151,8 +150,8 @@ exports.signXrpWithPrivateKey = function(txHex, privateKey, options) {
   if (privateKeyBuffer.length === 33 && privateKeyBuffer[0] === 0) {
     privateKeyBuffer = privateKeyBuffer.slice(1, 33);
   }
-  const privateKeyObject = prova.ECPair.fromPrivateKeyBuffer(privateKeyBuffer);
-  const publicKey = privateKeyObject.getPublicKeyBuffer().toString('hex').toUpperCase();
+  const ecPair = utxoLib.bitgo.keyutil.privateKeyBufferToECPair(privateKeyBuffer);
+  const publicKey = ecPair.getPublicKeyBuffer().toString('hex').toUpperCase();
 
   let tx;
   try {

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "key-recovery-service-v2",
       "version": "2.0.0",
       "license": "MIT",
       "dependencies": {
@@ -29,7 +30,6 @@
         "nodemailer": "^4.6.7",
         "nodemailer-smtp-transport": "^2.7.4",
         "prompt-sync": "^4.1.6",
-        "prova-lib": "^0.2.9",
         "q": "^1.5.1",
         "ripple-binary-codec": "^0.1.13",
         "ripple-hashes": "^0.3.1",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
     "nodemailer": "^4.6.7",
     "nodemailer-smtp-transport": "^2.7.4",
     "prompt-sync": "^4.1.6",
-    "prova-lib": "^0.2.9",
     "q": "^1.5.1",
     "ripple-binary-codec": "^0.1.13",
     "ripple-hashes": "^0.3.1",


### PR DESCRIPTION
This removes the lone `prova-lib` usage by replacing it with the equivalent functionality provided by utxo-lib.

Ticket: BG-33735